### PR TITLE
Feature/openresty ubi8micro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testbuild
 Dockerfile.orig
 Dockerfile.RHEL8
 **.swp
+testrun

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ server.key
 testbuild
 Dockerfile.orig
 Dockerfile.RHEL8
+**.swp

--- a/Dockerfile.builderonly
+++ b/Dockerfile.builderonly
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest as base
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 # dnsmasq comes from Centos due to a UBI issue (it doesn't exist in the RHEL7 repo)
 # The centos mirror is enabled only for the duration of installing dnsmasq
 ARG ORO=https://openresty.org/package/rhel/7/x86_64
@@ -19,7 +19,6 @@ RUN curl -L -o openresty.rpm $ORO/openresty-1.19.3.1-1.el7.x86_64.rpm && \
     microdnf clean all && \
     rpm --rebuilddb
 
-from base as builder
 RUN microdnf install git unzip gcc openssl-devel && \
     curl -LO https://luarocks.org/releases/luarocks-3.7.0.tar.gz && \
     tar -xf luarocks-3.7.0.tar.gz && \
@@ -37,8 +36,6 @@ RUN microdnf install git unzip gcc openssl-devel && \
     luarocks install lua-resty-hmac && \
     luarocks install lua-resty-openidc
 
-from base 
-COPY --from=builder /luarocks-3.7.0 .
 COPY server.crt /etc/nginx/server.crt
 COPY server.key /etc/nginx/server.key
 COPY auth.lua .

--- a/Dockerfile.ubi8
+++ b/Dockerfile.ubi8
@@ -1,0 +1,81 @@
+# Dockerfile - CentOS 8 - RPM version
+# https://github.com/openresty/docker-openresty
+
+ARG RESTY_IMAGE_BASE="registry.access.redhat.com/ubi8/ubi"
+ARG RESTY_IMAGE_TAG="8.4-213"
+
+FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
+
+LABEL maintainer="Evan Wies <evan@neomantra.net>"
+
+ARG RESTY_LUAROCKS_VERSION="3.7.0"
+ARG RESTY_YUM_REPO="https://openresty.org/package/centos/openresty.repo"
+ARG RESTY_RPM_FLAVOR=""
+ARG RESTY_RPM_VERSION="1.19.9.1-1"
+ARG RESTY_RPM_DIST="el8"
+ARG RESTY_RPM_ARCH="x86_64"
+
+LABEL resty_image_base="${RESTY_IMAGE_BASE}"
+LABEL resty_image_tag="${RESTY_IMAGE_TAG}"
+LABEL resty_luarocks_version="${RESTY_LUAROCKS_VERSION}"
+LABEL resty_yum_repo="${RESTY_YUM_REPO}"
+LABEL resty_rpm_flavor="${RESTY_RPM_FLAVOR}"
+LABEL resty_rpm_version="${RESTY_RPM_VERSION}"
+LABEL resty_rpm_dist="${RESTY_RPM_DIST}"
+LABEL resty_rpm_arch="${RESTY_RPM_ARCH}"
+
+
+RUN yum install -y yum-utils \
+    && yum-config-manager --add-repo ${RESTY_YUM_REPO} \
+    && yum install -y \
+        gettext \
+        gzip \
+        make \
+        openresty${RESTY_RPM_FLAVOR}-${RESTY_RPM_VERSION}.${RESTY_RPM_DIST}.${RESTY_RPM_ARCH} \
+        openresty-opm-${RESTY_RPM_VERSION}.${RESTY_RPM_DIST} \
+        openresty-resty-${RESTY_RPM_VERSION}.${RESTY_RPM_DIST} \
+        tar \
+        unzip \
+    && cd /tmp \
+    && curl -fSL https://luarocks.github.io/luarocks/releases/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && cd luarocks-${RESTY_LUAROCKS_VERSION} \
+    && ./configure \
+        --prefix=/usr/local/openresty/luajit \
+        --with-lua=/usr/local/openresty/luajit \
+        --lua-suffix=jit-2.1.0-beta3 \
+        --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1 \
+    && make build \
+    && make install \
+    && cd /tmp \
+    && rm -rf luarocks-${RESTY_LUAROCKS_VERSION} luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && yum clean all \
+    && mkdir -p /var/run/openresty \
+    && ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log
+
+# Unused, present for parity with other Dockerfiles
+# This makes some tooling/testing easier, as specifying a build-arg
+# and not consuming it fails the build.
+ARG RESTY_J="1"
+
+# Add additional binaries into PATH for convenience
+ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
+
+# Add LuaRocks paths
+# If OpenResty changes, these may need updating:
+#    /usr/local/openresty/bin/resty -e 'print(package.path)'
+#    /usr/local/openresty/bin/resty -e 'print(package.cpath)'
+ENV LUA_PATH="/usr/local/openresty/site/lualib/?.ljbc;/usr/local/openresty/site/lualib/?/init.ljbc;/usr/local/openresty/lualib/?.ljbc;/usr/local/openresty/lualib/?/init.ljbc;/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/site/lualib/?/init.lua;/usr/local/openresty/lualib/?.lua;/usr/local/openresty/lualib/?/init.lua;./?.lua;/usr/local/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;/usr/local/openresty/luajit/share/lua/5.1/?.lua;/usr/local/openresty/luajit/share/lua/5.1/?/init.lua"
+
+ENV LUA_CPATH="/usr/local/openresty/site/lualib/?.so;/usr/local/openresty/lualib/?.so;./?.so;/usr/local/lib/lua/5.1/?.so;/usr/local/openresty/luajit/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so;/usr/local/openresty/luajit/lib/lua/5.1/?.so"
+
+# Copy nginx configuration files
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+
+CMD ["/usr/bin/openresty", "-g", "daemon off;"]
+
+# Use SIGQUIT instead of default SIGTERM to cleanly drain requests
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#tips--pitfalls
+STOPSIGNAL SIGQUIT

--- a/Dockerfile.ubi8micro
+++ b/Dockerfile.ubi8micro
@@ -1,0 +1,26 @@
+FROM ubi8openresty as builder
+
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+
+ENV LUA_CPATH "/usr/local/openresty/site/lualib/?.so;/usr/local/openresty/lualib/?.so;./?.so;/usr/local/openresty/luajit/lib/lua/5.1/?.so;/usr/local/openresty/luajit/lib/lua/5.1/?.so"
+
+ENV LUA_PATH "/usr/local/openresty/site/lualib/?.ljbc;/usr/local/openresty/site/lualib/?/init.ljbc;/usr/local/openresty/lualib/?.ljbc;/usr/local/openresty/lualib/?/init.ljbc;/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/site/lualib/?/init.lua;/usr/local/openresty/lualib/?.lua;/usr/local/openresty/lualib/?/init.lua;./?.lua;/usr/local/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;/usr/local/openresty/luajit/share/lua/5.1/?.lua;/usr/local/openresty/luajit/share/lua/5.1/?/init.lua"
+
+ENV PATH "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin"
+
+COPY --from=builder /usr/local/openresty /usr/local/openresty/
+COPY --from=builder /usr/bin/openresty /usr/bin/
+COPY --from=builder /etc/nginx /etc/nginx/
+COPY --from=builder /usr/lib64/libcrypt* /usr/lib64/
+COPY --from=builder /usr/lib64/libgcc* /usr/lib64/
+
+# Copy nginx configuration files
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+
+RUN mkdir -p /var/run/openresty
+# Use SIGQUIT instead of default SIGTERM to cleanly drain requests
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#tips--pitfalls
+STOPSIGNAL SIGQUIT
+
+CMD ["/usr/bin/openresty", "-g", "daemon off;"]

--- a/buildAndRun
+++ b/buildAndRun
@@ -1,0 +1,2 @@
+#! /bin/sh
+docker build -f Dockerfile.ubi8micro -t ubi8openrestymicro . && docker run -it --network=host --rm ubi8openrestymicro

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,18 @@
+lua_interpreter = "lua"
+rocks_trees = {
+   {
+      name = "user",
+      root = "/root/.luarocks"
+   },
+   {
+      name = "system",
+      root = "/usr/local"
+   }
+}
+variables = {
+   LUA_BINDIR = "/usr/bin",
+   LUA_DIR = "/usr",
+   LUA_INCDIR = "/usr/local/openresty/luajit/include/luajit-2.1",
+   LUA_LIBDIR = "/usr/local/openresty/luajit/lib"
+}
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,99 @@
+# nginx.conf  --  docker-openresty
+#
+# This file is installed to:
+#   `/usr/local/openresty/nginx/conf/nginx.conf`
+# and is the file loaded by nginx at startup,
+# unless the user specifies otherwise.
+#
+# It tracks the upstream OpenResty's `nginx.conf`, but removes the `server`
+# section and adds this directive:
+#     `include /etc/nginx/conf.d/*.conf;`
+#
+# The `docker-openresty` file `nginx.vh.default.conf` is copied to
+# `/etc/nginx/conf.d/default.conf`.  It contains the `server section
+# of the upstream `nginx.conf`.
+#
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#nginx-config-files
+#
+
+#user  nobody;
+#worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    # Enables or disables the use of underscores in client request header fields.
+    # When the use of underscores is disabled, request header fields whose names contain underscores are marked as invalid and become subject to the ignore_invalid_headers directive.
+    # underscores_in_headers off;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  logs/access.log  main;
+
+        # Log in JSON Format
+        # log_format nginxlog_json escape=json '{ "timestamp": "$time_iso8601", '
+        # '"remote_addr": "$remote_addr", '
+        #  '"body_bytes_sent": $body_bytes_sent, '
+        #  '"request_time": $request_time, '
+        #  '"response_status": $status, '
+        #  '"request": "$request", '
+        #  '"request_method": "$request_method", '
+        #  '"host": "$host",'
+        #  '"upstream_addr": "$upstream_addr",'
+        #  '"http_x_forwarded_for": "$http_x_forwarded_for",'
+        #  '"http_referrer": "$http_referer", '
+        #  '"http_user_agent": "$http_user_agent", '
+        #  '"http_version": "$server_protocol", '
+        #  '"nginx_access": true }';
+        # access_log /dev/stdout nginxlog_json;
+
+    # See Move default writable paths to a dedicated directory (#119)
+    # https://github.com/openresty/docker-openresty/issues/119
+    client_body_temp_path /var/run/openresty/nginx-client-body;
+    proxy_temp_path       /var/run/openresty/nginx-proxy;
+    fastcgi_temp_path     /var/run/openresty/nginx-fastcgi;
+    uwsgi_temp_path       /var/run/openresty/nginx-uwsgi;
+    scgi_temp_path        /var/run/openresty/nginx-scgi;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    # Don't reveal OpenResty version to clients.
+    # server_tokens off;
+    server {
+        listen 8080;
+        location / {
+            default_type text/html;
+            content_by_lua_block {
+                ngx.say("<p>hello, world</p>")
+            }
+        }
+    }
+}

--- a/nginx.template.conf
+++ b/nginx.template.conf
@@ -1,4 +1,6 @@
-user  nobody;
+#Reinstate the below line if running the container as root
+#user  nobody;
+
 worker_processes  1;
 #error_log  /dev/stdout  info;
 error_log /var/log/nginx/error.log info;

--- a/nginx.vh.default.conf
+++ b/nginx.vh.default.conf
@@ -1,0 +1,58 @@
+# nginx.vh.default.conf  --  docker-openresty
+#
+# This file is installed to:
+#   `/etc/nginx/conf.d/default.conf`
+#
+# It tracks the `server` section of the upstream OpenResty's `nginx.conf`.
+#
+# This config (and any other configs in `etc/nginx/conf.d/`) is loaded by
+# default by the `include` directive in `/usr/local/openresty/nginx/conf/nginx.conf`.
+#
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#nginx-config-files
+#
+
+
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/local/openresty/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/local/openresty/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           /usr/local/openresty/nginx/html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/testrun
+++ b/testrun
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -p 80:80 -d --rm --name op oauth2proxy
+docker run -p 80:80 -d --rm --name op stampcover/rhel7-openresty-cognito:0.2

--- a/testrun
+++ b/testrun
@@ -1,2 +1,0 @@
-#!/bin/sh
-docker run -p 80:80 -d --rm --name op stampcover/rhel7-openresty-cognito:0.2


### PR DESCRIPTION
Migrate to ubi8micro for the runtime image. Smaller runtime image with fewer dependencies to keep up to date. Refresh openresty packages